### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-guacadb} 
       POSTGRES_PASSWORD: 
+      POSTGRES_INITDB_ARGS: --auth-host=md5
     depends_on:
       - init-guac-db
 


### PR DESCRIPTION
Avoid SCRAM authentication due to the non-supported auth method in the driver.