### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
 
   init-guac-db:
     image: guacamole/guacamole:latest
-    command: ["/bin/sh", "-c", "test -e /init/initdb.sql && echo 'init file already exists' || /opt/guacamole/bin/initdb.sh --postgres > /init/initdb.sql" ]
+    command: ["/bin/sh", "-c", "test -e /init/initdb.sql && echo 'init file already exists' || /opt/guacamole/bin/initdb.sh --postgresql > /init/initdb.sql" ]
     volumes:
       - dbinit:/init    
 


### PR DESCRIPTION
Currently, the latest Guacamole image needs '--postgresql' instead of '--postgres' to initiate the database. It's not recognizing '--postgres,' as stated in 'initdb.sh: 
```
   @param DATABASE
    The database to generate the SQL script for. This may be either
    "--postgresql", for PostgreSQL, "--mysql" for MySQL, or "--sqlserver" for Microsoft SQL Server.
```